### PR TITLE
Refactor geo-cli.js

### DIFF
--- a/lib/update.js
+++ b/lib/update.js
@@ -8,6 +8,7 @@ const log = require('@harrytwright/logger')
 
 const cli = require('./cli')
 const Usage = require('./utils/usage')
+const prefix = require('./utils/prefix')
 const { bulk } = require('./update/bulk')
 const merge = require('./update/merge').exec
 const tmp = require('./utils/tmp').customName
@@ -22,9 +23,12 @@ update.usage = new Usage('update', '\nUpdate the external data with new informat
 
 update.run = function (argv, cb) {
   const where = argv[0] ? argv[0] : cli.config.get('dir')
+  cli.config.set('dir', where || cli.config.get('dir'))
 
-  if (!fs.existsSync(path.join(where, './docker/database/data')) || !fs.existsSync(path.join(where, './docker/elasticsearch/data'))) {
-    const error = new Error('Missing requried datasources')
+  const _where = prefix(cli.config.get('prefix'))
+
+  if (!fs.existsSync(path.dirname(_where('mongodb', 'file.ext'))) || !fs.existsSync(path.dirname(_where('elasticsearch', 'file.ext')))) {
+    const error = new Error('Missing required datasources')
     error.file = !fs.existsSync(path.join(where, './docker/database/data'))
       ? path.join(where, './docker/database/data')
       : path.join(where, './docker/elasticsearch/data')
@@ -32,11 +36,11 @@ update.run = function (argv, cb) {
     throw error
   }
 
-  return new Updater(where, argv).run(cb)
+  return new Updater(_where, argv).run(cb)
 }
 
-function Updater (where, args) {
-  this.where = where
+function Updater (prefix, args) {
+  this.prefix = prefix
 
   this.args = args
 
@@ -64,8 +68,9 @@ Updater.prototype.run = function (_cb) {
   const command = check()
 
   if (command === check.COMMANDS.MONGODB || command === check.COMMANDS.ALL) {
+    const where = path.dirname(this.prefix('mongodb', 'file.ext'))
     steps.push(
-      [mongoimport, path.join(this.where, './docker/database/data'), {
+      [mongoimport, where, {
         uri: cli.config.get('mongouri'),
         collection: cli.config.get('collection')
       }]
@@ -73,7 +78,7 @@ Updater.prototype.run = function (_cb) {
   }
 
   if (command === check.COMMANDS.ELASTICSEARCH || command === check.COMMANDS.ALL) {
-    const where = path.join(this.where, './docker/elasticsearch/data')
+    const where = path.dirname(this.prefix('elasticsearch', 'file.ext'))
     const mergedData = path.join(where, './geolocation.ndjson')
     const response = tmp('json')
 

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
     "geo": "./bin/geo-cli.js"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "postversion": "git push origin --all; git push origin --tags"
+    "test": "echo \"Error: no test specified\"",
+    "preversion": "npm test",
+    "postversion": "npm publish",
+    "postpublish": "git push origin --all; git push origin --tags"
   },
   "keywords": [
     "cli"


### PR DESCRIPTION
> These here could tie into `2.0.0`, to make for a more justified reason for the major update

Right now, both check and generate run the same commands, but generate continues after it has reviewed and acted upon the updates, so for now, we would look at adding a custom `geospatial-lib` package. That would handle the generation of the data and its updates, and both `geo check` && `geo generate` would be proxies off.

## Ideas

### Geospatial-lib

Refactoring the shared code from both `generate.js` and `check.js` we could allow for a smaller code base since they both do the same things, only the `dry-run` argument would need to be passed so `check.js` will not update the cache.

### Programmatical usage

This too, could be useful for creating more accessible tests, Move from the idea of `geo-cli.js ~> cli.js` but instead that we have a `geo.js`. Then, `geo.js` acts as the index to the code, and the `cli.js` just is the map to the outside world?